### PR TITLE
Remove this crate's dependence on libstd

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,9 +2,12 @@
 //!
 //! A [`Waker`] is just a fancy callback. This crate converts regular closures into wakers.
 
-use std::mem::{self, ManuallyDrop};
-use std::sync::Arc;
-use std::task::{RawWaker, RawWakerVTable, Waker};
+#![no_std]
+extern crate alloc;
+
+use alloc::sync::Arc;
+use core::mem::{self, ManuallyDrop};
+use core::task::{RawWaker, RawWakerVTable, Waker};
 
 /// Converts a closure into a [`Waker`].
 ///


### PR DESCRIPTION
This pull request changes all of the imports from libstd into imports from libcore and liballoc. My purpose for doing this is that I want to use the `futures_core` crate in a `no_std` environment; however, it depends on this crate, which currently requires libstd.