### PR TITLE
Remove readme field from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,3 @@ homepage = "https://github.com/smol-rs/waker-fn"
 documentation = "https://docs.rs/waker-fn"
 keywords = ["async", "waker", "wake", "closure", "callback"]
 categories = ["concurrency"]
-readme = "README.md"


### PR DESCRIPTION
Since 1.46, cargo can automatically detect the value of the readme field.