### PR TITLE
Add portable-atomic feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
         if: startsWith(matrix.rust, 'nightly')
         run: cargo check -Z features=dev_dep
       - run: cargo test
+      - run: cargo test --features portable-atomic
 
   msrv:
     runs-on: ubuntu-latest
@@ -79,6 +80,10 @@ jobs:
       - name: Install Rust
         run: rustup toolchain install nightly --component miri && rustup default nightly
       - run: cargo miri test
+        env:
+          MIRIFLAGS: -Zmiri-strict-provenance -Zmiri-symbolic-alignment-check -Zmiri-disable-isolation
+          RUSTFLAGS: ${{ env.RUSTFLAGS }} -Z randomize-layout
+      - run: cargo miri test --features portable-atomic
         env:
           MIRIFLAGS: -Zmiri-strict-provenance -Zmiri-symbolic-alignment-check -Zmiri-disable-isolation
           RUSTFLAGS: ${{ env.RUSTFLAGS }} -Z randomize-layout

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,10 @@ documentation = "https://docs.rs/waker-fn"
 keywords = ["async", "waker", "wake", "closure", "callback"]
 categories = ["concurrency"]
 exclude = ["/.*"]
+
+[features]
+# Uses portable-atomic polyfill atomics on targets without them
+portable-atomic = ["portable-atomic-util"]
+
+[dependencies]
+portable-atomic-util = { version = "0.2", optional = true, default-features = false, features = ["alloc"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,11 +12,14 @@
     html_logo_url = "https://raw.githubusercontent.com/smol-rs/smol/master/assets/images/logo_fullsize_transparent.png"
 )]
 
+#[cfg(not(feature = "portable-atomic"))]
 extern crate alloc;
 
-use alloc::sync::Arc;
-use alloc::task::Wake;
+#[cfg(not(feature = "portable-atomic"))]
+use alloc::{sync::Arc, task::Wake};
 use core::task::Waker;
+#[cfg(feature = "portable-atomic")]
+use portable_atomic_util::{task::Wake, Arc};
 
 /// Converts a closure into a [`Waker`].
 ///
@@ -38,6 +41,7 @@ pub fn waker_fn<F: Fn() + Send + Sync + 'static>(f: F) -> Waker {
 
 struct Helper<F>(F);
 
+#[cfg(not(feature = "portable-atomic"))]
 impl<F: Fn() + Send + Sync + 'static> Wake for Helper<F> {
     fn wake(self: Arc<Self>) {
         (self.0)();
@@ -45,5 +49,18 @@ impl<F: Fn() + Send + Sync + 'static> Wake for Helper<F> {
 
     fn wake_by_ref(self: &Arc<Self>) {
         (self.0)();
+    }
+}
+// Note: Unlike std::task::Wake, all methods take `this:` instead of `self:`.
+// This is because using portable_atomic_util::Arc as a receiver requires the
+// unstable arbitrary_self_types feature.
+#[cfg(feature = "portable-atomic")]
+impl<F: Fn() + Send + Sync + 'static> Wake for Helper<F> {
+    fn wake(this: Arc<Self>) {
+        (this.0)();
+    }
+
+    fn wake_by_ref(this: &Arc<Self>) {
+        (this.0)();
     }
 }


### PR DESCRIPTION
portable-atomic-util now provides `std::task::Wake` equivalent: https://github.com/taiki-e/portable-atomic/pull/145
This allows crates like waker-fn to support targets without atomics.
