### PR TITLE
v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 1.2.0
+
+- Add a new `portable-atomic` feature that allows for the usage of the
+  `portable-atomic` crate to implement `waker-fn`. (#10)
+
 # Version 1.1.1
 
 - Reimplement using 100% safe code. (#7)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "waker-fn"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v1.x.y" git tag
-version = "1.1.1"
+version = "1.2.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2018"
 rust-version = "1.51"


### PR DESCRIPTION
- Add a new `portable-atomic` feature that allows for the usage of the
  `portable-atomic` crate to implement `waker-fn`. (#10)
