### PR TITLE
feat: add 'alloc' feature and `waker_fn_ptr`, zero-allocation waker from fn pointer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,9 @@ exclude = ["/.*"]
 
 [features]
 # Uses portable-atomic polyfill atomics on targets without them
+default = ["alloc"]
 portable-atomic = ["portable-atomic-util"]
+alloc = []
 
 [dependencies]
 portable-atomic-util = { version = "0.2", optional = true, default-features = false, features = ["alloc"] }


### PR DESCRIPTION
This PR adds zero-allocation and `const` way to create a waker from the function pointer.

Rust can automatically convert `|| ...` clojures into `fn()` pointers if they don't capture anything, so example from the readme would work with `waker_fn_ptr` too.